### PR TITLE
Correct github-link (to other projects)

### DIFF
--- a/_posts/2019-02-25-historische-kaarten.md
+++ b/_posts/2019-02-25-historische-kaarten.md
@@ -151,7 +151,7 @@ map.setView([52.4158, 4.9768], 10)
 </script>
 ```
 
-[Op GitHub](https://github.com/Amsterdam/explore-historical-maps/viewer) staan een aantal voorbeeldprojecten die laten zien hoe je de Publieke Werken-kaarten met Leaflet kunt gebruiken. Wanneer we meer historische kaartlagen toevoegen aan het dataportaal wijden we er een nieuwe post aan op het Datablog!
+[Op GitHub](https://github.com/Amsterdam/explore-historical-maps) staan een aantal voorbeeldprojecten die laten zien hoe je de Publieke Werken-kaarten met Leaflet kunt gebruiken. Wanneer we meer historische kaartlagen toevoegen aan het dataportaal wijden we er een nieuwe post aan op het Datablog!
 
 <!-- ### OpenLayers -->
 


### PR DESCRIPTION
There is nothing at https://github.com/Amsterdam/explore-historical-maps/viewer, so I asume that the root folder (https://github.com/Amsterdam/explore-historical-maps) was meant.

(en dank voor dit blog!!)